### PR TITLE
SEO: update page titles to remove duplicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+---
+title: "Capture Vision Server SDK \u2013 Docs & API Overview"
+---
+
 # Dynamsoft Capture Vision Docs
 
 This is the repository for maintaining the official documentation of Dynamsoft Capture Vision.

--- a/programming/cplusplus/api-reference/core/enum-buffer-overflow-protection-mode.md
+++ b/programming/cplusplus/api-reference/core/enum-buffer-overflow-protection-mode.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: BufferOverflowProtectionMode - Dynamsoft Core Enumerations
+title: BufferOverflowProtectionMode – Capture Vision C++ Enum Reference
 description: Reference for the BufferOverflowProtectionMode enumeration in Dynamsoft Core C++ Edition, describing strategies when the image source buffer overflows (ignore new, update oldest).
 keywords: Buffer overflow protection mode 
 needGenerateH3Content: true

--- a/programming/cplusplus/api-reference/core/enum-colour-channel-usage-type.md
+++ b/programming/cplusplus/api-reference/core/enum-colour-channel-usage-type.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: ColourChannelUsageType - Dynamsoft Core Enumerations
+title: ColourChannelUsageType – Dynamsoft Capture Vision C++ Enum Ref
 description: Reference for the ColourChannelUsageType enumeration in Dynamsoft Core C++ Edition, describing how colour channels are used during image processing.
 keywords: Corner type
 needGenerateH3Content: true

--- a/programming/cplusplus/api-reference/core/enum-grayscale-enhancement-mode.md
+++ b/programming/cplusplus/api-reference/core/enum-grayscale-enhancement-mode.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: GrayscaleEnhancementMode - Dynamsoft Core Enumerations
+title: GrayscaleEnhancementMode – Capture Vision C++ Enum Reference
 description: Reference for the GrayscaleEnhancementMode enumeration in Dynamsoft Core C++ Edition, listing available image enhancement algorithms applied to grayscale images before recognition.
 keywords: Grayscale enhancement modes
 needGenerateH3Content: true

--- a/programming/cplusplus/api-reference/core/enum-grayscale-transformation-mode.md
+++ b/programming/cplusplus/api-reference/core/enum-grayscale-transformation-mode.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: GrayscaleTransformationMode - Dynamsoft Core Enumerations
+title: GrayscaleTransformationMode – Capture Vision C++ Enum Ref
 description: Reference for the GrayscaleTransformationMode enumeration in Dynamsoft Core C++ Edition, describing transformations (invert, original) applied when converting a colour image to grayscale.
 keywords: Grayscale transformation modes
 needGenerateH3Content: true

--- a/programming/cplusplus/api-reference/core/enum-image-pixel-format.md
+++ b/programming/cplusplus/api-reference/core/enum-image-pixel-format.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: ImagePixelFormat - Dynamsoft Core Enumerations
+title: ImagePixelFormat – Dynamsoft Capture Vision C++ Enum Ref
 description: Reference for the ImagePixelFormat enumeration in Dynamsoft Core C++ Edition, listing all supported pixel formats (grayscale, RGB, RGBA, etc.) for image data.
 keywords: Image pixel format
 needGenerateH3Content: true

--- a/programming/cplusplus/api-reference/core/enum-intermediate-result-unit-type.md
+++ b/programming/cplusplus/api-reference/core/enum-intermediate-result-unit-type.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: IntermediateResultUnitType - Dynamsoft Core Enumerations
+title: IntermediateResultUnitType – Capture Vision C++ Enum Reference
 description: Reference for the IntermediateResultUnitType enumeration in Dynamsoft Core C++ Edition, listing all types of intermediate result units produced during image processing.
 keywords: Intermediate result unit type
 needGenerateH3Content: true

--- a/programming/cplusplus/api-reference/core/enum-region-object-element-type.md
+++ b/programming/cplusplus/api-reference/core/enum-region-object-element-type.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: RegionObjectElementType - Dynamsoft Core Enumerations
+title: RegionObjectElementType – Capture Vision C++ Enum Reference
 description: Reference for the RegionObjectElementType enumeration in Dynamsoft Core C++ Edition, listing the types of region object elements (localized, recognized, etc.).
 keywords: Region object element type
 needGenerateH3Content: true

--- a/programming/cplusplus/api-reference/core/enum-section-type.md
+++ b/programming/cplusplus/api-reference/core/enum-section-type.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: SectionType - Dynamsoft Core Enumerations
+title: SectionType Enum – Dynamsoft Capture Vision C++ API Reference
 description: Reference for the SectionType enumeration in Dynamsoft Core C++ Edition, identifying the processing section (region detection, barcode localization, barcode decoding, etc.) that produced a result.
 keywords: Section type
 needGenerateH3Content: true

--- a/programming/cplusplus/api-reference/utility/enum-filter-type.md
+++ b/programming/cplusplus/api-reference/utility/enum-filter-type.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: FilterType - Dynamsoft Utility Enumerations
+title: FilterType Enum – Dynamsoft Capture Vision C++ Utility API
 description: Reference for the FilterType enumeration in Dynamsoft Utility C++ Edition, specifying the image filter type applied during image processing operations.
 keywords: image filter
 codeAutoHeight: true

--- a/programming/java/api-reference/utility/enum-filter-type.md
+++ b/programming/java/api-reference/utility/enum-filter-type.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: FilterType - Dynamsoft Utility Enumerations
+title: FilterType Enum – Dynamsoft Capture Vision Java Utility API
 description: The enumeration FilterType in Dynamsoft Utility Java Edition specifies the type of image filter applied during image processing operations.
 keywords: image filter
 codeAutoHeight: true

--- a/programming/python/api-reference/core/enum-cross-verification-status.md
+++ b/programming/python/api-reference/core/enum-cross-verification-status.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: CrossVerificationStatus - Dynamsoft Core Enumerations
+title: CrossVerificationStatus Enum – Capture Vision Python SDK Ref
 description: The enumeration CrossVerificationStatus in Dynamsoft Core Python Edition indicates whether a captured result has been cross-verified across multiple frames.
 keywords: cross verification status
 codeAutoHeight: true

--- a/programming/python/api-reference/core/enum-video-frame-quality.md
+++ b/programming/python/api-reference/core/enum-video-frame-quality.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: VideoFrameQuality - Dynamsoft Core Enumerations
+title: VideoFrameQuality Enum – Capture Vision Python SDK Reference
 description: The enumeration VideoFrameQuality in Dynamsoft Core Python Edition classifies video frame quality (high or low) to control which frames are processed.
 keywords: Video frame quality
 needGenerateH3Content: true

--- a/programming/python/api-reference/utility/enum-filter-type.md
+++ b/programming/python/api-reference/utility/enum-filter-type.md
@@ -1,6 +1,6 @@
 ---
 layout: default-layout
-title: FilterType - Dynamsoft Utility Enumerations
+title: FilterType Enum – Dynamsoft Capture Vision Python Utility API
 description: The enumeration FilterType in Dynamsoft Utility Python Edition specifies the type of image filter applied during image processing operations.
 keywords: image filter
 codeAutoHeight: true


### PR DESCRIPTION
## Summary
- Update 13 page titles across C++, Java, and Python API references to ensure unique titles for better SEO indexing
- Affected pages: enum references (BufferOverflowProtectionMode, ColourChannelUsageType, GrayscaleEnhancementMode, etc.) and utility FilterType enums

## Note
- 1 page (`/capture-vision/docs/server/`) could not be updated — no `index.md` found at repo root. This landing page title may need to be set elsewhere.